### PR TITLE
Adding remote shutdown + remote reboot functionality 

### DIFF
--- a/Agent/main.go
+++ b/Agent/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -83,7 +84,7 @@ func main() {
 
 	// Checks in every 10 seconds.
 	for {
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 		checkIn()
 	}
 
@@ -199,11 +200,43 @@ func checkIn() {
 
 }
 
-func shutdown() {
+// func shutdown() {
 
-	fmt.Println("Beep Boop. This feature isn't implemented yet")
+// 	// fmt.Println("Beep Boop. This feature isn't implemented yet")
 
-	/// This is where the code to shutdown the PC will go
+// 	// platform := runtime.GOOS
+
+// 	// fmt.Println(platform)
+
+// 	// if platform == "darwin" {
+
+// 	// 	fmt.Println("The platform is darwin")
+
+// 	// 	runCommand("shutdown")
+// 	// }
+
+// 	// if err := exec.Command("cmd", "/C", "shutdown", "/s").Run(); err != nil {
+//     // 	fmt.Println("Failed to initiate shutdown:", err)
+// 	// }
+
+// 	// /// This is where the code to shutdown the PC will go
+// }
+
+// Function for shutting down PC
+func shutdown() error {
+	switch os := runtime.GOOS; os {
+	case "linux":
+		cmd := exec.Command("shutdown", "-h", "now")
+		return cmd.Run()
+	case "darwin":
+		cmd := exec.Command("shutdown", "-h", "now")
+		return cmd.Run()
+	case "windows":
+		cmd := exec.Command("shutdown", "/s", "/t", "0")
+		return cmd.Run()
+	default:
+		return errors.New("Shutdown failed: Can't find platform")
+	}
 }
 
 func getFIle() {

--- a/Agent/main.go
+++ b/Agent/main.go
@@ -190,7 +190,7 @@ func checkIn() {
 	case "run script":
 		fmt.Println("Hello there")
 	case "shutdown":
-		shutdown()
+		shutdown(post.TaskID)
 	case "run command":
 		go handle_runCommand(post.TaskID, post.Arg)
 	default:
@@ -223,20 +223,45 @@ func checkIn() {
 // }
 
 // Function for shutting down PC
-func shutdown() error {
+func shutdown(task_id string) error {
+
+	var response Task_Response
+
+	response = Task_Response{task_id, "Success", "Shutdown Command Received"}
+
 	switch os := runtime.GOOS; os {
 	case "linux":
-		cmd := exec.Command("shutdown", "-h", "now")
-		return cmd.Run()
+		send_response(response)
+		out, err := exec.Command("shutdown", "-h", "now").Output()
+		if err != nil {
+			response = Task_Response{task_id, "Failed", string(out)}
+			send_response(response)
+			return err
+		}
 	case "darwin":
-		cmd := exec.Command("shutdown", "-h", "now")
-		return cmd.Run()
+		send_response(response)
+		out, err := exec.Command("shutdown", "-h", "now").Output()
+		if err != nil {
+			response = Task_Response{task_id, "Failed", string(out)}
+			send_response(response)
+			return err
+		}
 	case "windows":
-		cmd := exec.Command("shutdown", "/s", "/t", "0")
-		return cmd.Run()
+		send_response(response)
+		out, err := exec.Command("shutdown", "/s", "/t", "0").Output()
+		if err != nil {
+			response = Task_Response{task_id, "Failed", string(out)}
+			send_response(response)
+			return err
+		}
 	default:
-		return errors.New("Shutdown failed: Can't find platform")
+		fmt.Println("shutdown failed")
 	}
+
+	response = Task_Response{task_id, "Failed", "Machine has not shutdown"}
+	send_response(response)
+	return errors.New("shutdown failed: Can't find platform")
+
 }
 
 func getFIle() {

--- a/Agent/main.go
+++ b/Agent/main.go
@@ -191,6 +191,8 @@ func checkIn() {
 		fmt.Println("Hello there")
 	case "shutdown":
 		shutdown(post.TaskID)
+	case "reboot":
+		reboot(post.TaskID)
 	case "run command":
 		go handle_runCommand(post.TaskID, post.Arg)
 	default:
@@ -199,28 +201,6 @@ func checkIn() {
 	}
 
 }
-
-// func shutdown() {
-
-// 	// fmt.Println("Beep Boop. This feature isn't implemented yet")
-
-// 	// platform := runtime.GOOS
-
-// 	// fmt.Println(platform)
-
-// 	// if platform == "darwin" {
-
-// 	// 	fmt.Println("The platform is darwin")
-
-// 	// 	runCommand("shutdown")
-// 	// }
-
-// 	// if err := exec.Command("cmd", "/C", "shutdown", "/s").Run(); err != nil {
-//     // 	fmt.Println("Failed to initiate shutdown:", err)
-// 	// }
-
-// 	// /// This is where the code to shutdown the PC will go
-// }
 
 // Function for shutting down PC
 func shutdown(task_id string) error {
@@ -249,6 +229,47 @@ func shutdown(task_id string) error {
 	case "windows":
 		send_response(response)
 		out, err := exec.Command("shutdown", "/s", "/t", "0").Output()
+		if err != nil {
+			response = Task_Response{task_id, "Failed", string(out)}
+			send_response(response)
+			return err
+		}
+	default:
+		fmt.Println("shutdown failed")
+	}
+
+	response = Task_Response{task_id, "Failed", "Machine has not shutdown"}
+	send_response(response)
+	return errors.New("shutdown failed: Can't find platform")
+
+}
+
+func reboot(task_id string) error {
+
+	var response Task_Response
+
+	response = Task_Response{task_id, "Success", "Shutdown Command Received"}
+
+	switch os := runtime.GOOS; os {
+	case "linux":
+		send_response(response)
+		out, err := exec.Command("reboot").Output()
+		if err != nil {
+			response = Task_Response{task_id, "Failed", string(out)}
+			send_response(response)
+			return err
+		}
+	case "darwin":
+		send_response(response)
+		out, err := exec.Command("reboot").Output()
+		if err != nil {
+			response = Task_Response{task_id, "Failed", string(out)}
+			send_response(response)
+			return err
+		}
+	case "windows":
+		send_response(response)
+		out, err := exec.Command("shutdown", "/r", "/t", "0").Output()
 		if err != nil {
 			response = Task_Response{task_id, "Failed", string(out)}
 			send_response(response)

--- a/Console/main.go
+++ b/Console/main.go
@@ -109,6 +109,10 @@ func shutdown(node string) {
 	task_id := create_task_by_ID(node, "shutdown", "", "2")
 
 	fmt.Println("Shutdown Task created (" + task_id + ")")
+
+	time.Sleep(5 * time.Second)
+
+	get_task_by_id(task_id)
 }
 
 func handle_run(node string) {

--- a/Console/main.go
+++ b/Console/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 )
 
 type New_Task struct {
@@ -61,6 +62,7 @@ func main() {
 			fmt.Println("ls 			- List all nodes")
 			fmt.Println("tasks <node> 		- Display the tasks associated with a specific device. Leave blank to show all tasks")
 			fmt.Println("run <node> 		- Run a single command on a Node")
+			fmt.Println("shutdown <node> 	- shutdown device")
 			fmt.Println("Exit 			- Exit the NiceC2 interface")
 
 		}
@@ -91,8 +93,22 @@ func main() {
 
 		}
 
+		if strings.HasPrefix(text, "shutdown") {
+			node := text[9:]
+
+			shutdown(node)
+
+		}
+
 	}
 
+}
+
+func shutdown(node string) {
+
+	task_id := create_task_by_ID(node, "shutdown", "", "2")
+
+	fmt.Println("Shutdown Task created (" + task_id + ")")
 }
 
 func handle_run(node string) {
@@ -109,7 +125,14 @@ func handle_run(node string) {
 	// convert CRLF to LF
 	command = strings.Replace(command, "\n", "", -1)
 
-	create_task_by_ID(node, "run command", command, "2")
+	task_id := create_task_by_ID(node, "run command", command, "2")
+
+	fmt.Println("Waiting for command")
+
+	// Waiting three seconds for command to complete
+	time.Sleep(3 * time.Second)
+
+	get_task_by_id(task_id)
 
 }
 
@@ -248,7 +271,7 @@ func get_nodes() {
 
 }
 
-func create_task_by_ID(nodeID string, task string, arg string, key string) {
+func create_task_by_ID(nodeID string, task string, arg string, key string) string {
 
 	// This allows us to use a self signed certificate.
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
@@ -286,6 +309,30 @@ func create_task_by_ID(nodeID string, task string, arg string, key string) {
 	}
 
 	fmt.Println("Task submitted.  	TaskID: " + response.TaskID)
+
+	return response.TaskID
+
+}
+
+func get_task_by_id(input string) {
+
+	get_tasks()
+
+	// // Displays the tasks in a sort of table thing. needs to be done better
+	for _, task := range tasks {
+		if task.TaskID == input {
+			fmt.Println("######################################")
+			fmt.Println("Task ID:		" + task.TaskID)
+			fmt.Println("Action:			" + task.Action) // No idea why two tabs 🤷
+			fmt.Println("Argument: 		" + task.Content)
+			fmt.Println("Progress: 		" + task.Progress)
+			fmt.Println("Result: ")
+			fmt.Println("----")
+			fmt.Println(task.Result)
+			fmt.Println("======================================")
+
+		}
+	}
 
 }
 

--- a/Console/main.go
+++ b/Console/main.go
@@ -109,24 +109,16 @@ func main() {
 }
 
 func shutdown(node string) {
-
 	task_id := create_task_by_ID(node, "shutdown", "", "2")
-
 	fmt.Println("Shutdown Task created (" + task_id + ")")
-
-	time.Sleep(5 * time.Second)
-
+	time.Sleep(5 * time.Second) // Time is added to wait for command to get to / be run on node
 	get_task_by_id(task_id)
 }
 
 func reboot(node string) {
-
 	task_id := create_task_by_ID(node, "reboot", "", "2")
-
 	fmt.Println("Reboot Task created (" + task_id + ")")
-
-	time.Sleep(5 * time.Second)
-
+	time.Sleep(5 * time.Second) // Time is added to wait for command to get to / be run on node
 	get_task_by_id(task_id)
 }
 

--- a/Console/main.go
+++ b/Console/main.go
@@ -63,6 +63,7 @@ func main() {
 			fmt.Println("tasks <node> 		- Display the tasks associated with a specific device. Leave blank to show all tasks")
 			fmt.Println("run <node> 		- Run a single command on a Node")
 			fmt.Println("shutdown <node> 	- shutdown device")
+			fmt.Println("reboot <node>		- reboot")
 			fmt.Println("Exit 			- Exit the NiceC2 interface")
 
 		}
@@ -95,9 +96,12 @@ func main() {
 
 		if strings.HasPrefix(text, "shutdown") {
 			node := text[9:]
-
 			shutdown(node)
+		}
 
+		if strings.HasPrefix(text, "reboot") {
+			node := text[7:]
+			reboot(node)
 		}
 
 	}
@@ -109,6 +113,17 @@ func shutdown(node string) {
 	task_id := create_task_by_ID(node, "shutdown", "", "2")
 
 	fmt.Println("Shutdown Task created (" + task_id + ")")
+
+	time.Sleep(5 * time.Second)
+
+	get_task_by_id(task_id)
+}
+
+func reboot(node string) {
+
+	task_id := create_task_by_ID(node, "reboot", "", "2")
+
+	fmt.Println("Reboot Task created (" + task_id + ")")
 
 	time.Sleep(5 * time.Second)
 


### PR DESCRIPTION
Using the syntax `reboot/shutdown <node>` i can now reboot/shutdown nodes remotely. There is a system for reporting whether the action was successful or not. 